### PR TITLE
Disable browser autocomplete for the search field

### DIFF
--- a/templates/search.phtml
+++ b/templates/search.phtml
@@ -11,7 +11,7 @@
 <nav>
     <div class="wrapper">
         <div id="searchbar">
-            <input name="q" id="q" placeholder="Search" type="text">
+            <input name="q" id="q" placeholder="Search" type="text" autocomplete="off">
             <div id="searchicon" class="icon">search</div>
         </div>
     </div>


### PR DESCRIPTION
The page already provides an autocomplete mechanism, so this patch
prevents the browser autocomplete dropdown from being displayed if
the search box is clicked twice.
